### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,16 +5,16 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/pico/*.cpp"
 )
 
-add_library(IoAbstraction INTERFACE ${SOURCES})
+add_library(IoAbstraction ${SOURCES})
 
 target_compile_definitions(IoAbstraction
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(IoAbstraction INTERFACE
+target_include_directories(IoAbstraction PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(IoAbstraction INTERFACE
+target_link_libraries(IoAbstraction PUBLIC
         pico_stdlib pico_sync hardware_i2c hardware_spi hardware_adc hardware_pwm
         SimpleCollections TaskManagerIO)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,18 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
 
-
-file(GLOB SOURCES 
-        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/../src/pico/*.cpp"
+add_library(IoAbstraction
+        ../src/EepromAbstraction.cpp
+        ../src/EepromAbstractionWire.cpp
+        ../src/IoAbstraction.cpp
+        ../src/IoAbstractionWire.cpp
+        ../src/KeyboardManager.cpp
+        ../src/ResistiveTouchScreen.cpp
+        ../src/SwitchInput.cpp
+        ../src/wireHelpers.cpp
+        ../src/pico/PicoDigitalIO.cpp
+        ../src/pico/i2cWrapper.cpp
+        ../src/pico/picoAnalogDevice.cpp
 )
-
-add_library(IoAbstraction ${SOURCES})
 
 target_compile_definitions(IoAbstraction
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(IoAbstraction PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(IoAbstraction PUBLIC

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -5,16 +5,16 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/pico/*.cpp"
 )
 
-add_library(IoAbstraction ${SOURCES})
+add_library(IoAbstraction INTERFACE ${SOURCES})
 
 target_compile_definitions(IoAbstraction
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(IoAbstraction PUBLIC
+target_include_directories(IoAbstraction INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(IoAbstraction PUBLIC
+target_link_libraries(IoAbstraction INTERFACE
         pico_stdlib pico_sync hardware_i2c hardware_spi hardware_adc hardware_pwm
         SimpleCollections TaskManagerIO)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,23 +1,18 @@
-add_library(IoAbstraction
-        ../src/EepromAbstraction.cpp
-        ../src/EepromAbstractionWire.cpp
-        ../src/IoAbstraction.cpp
-        ../src/IoAbstractionWire.cpp
-        ../src/KeyboardManager.cpp
-        ../src/ResistiveTouchScreen.cpp
-        ../src/SwitchInput.cpp
-        ../src/wireHelpers.cpp
-        ../src/pico/PicoDigitalIO.cpp
-        ../src/pico/i2cWrapper.cpp
-        ../src/pico/picoAnalogDevice.cpp
+
+
+file(GLOB SOURCES 
+        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/../src/pico/*.cpp"
 )
+
+add_library(IoAbstraction ${SOURCES})
 
 target_compile_definitions(IoAbstraction
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
 target_include_directories(IoAbstraction PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/IoAbstraction/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(IoAbstraction PUBLIC

--- a/src/AnalogDeviceAbstraction.h
+++ b/src/AnalogDeviceAbstraction.h
@@ -7,7 +7,7 @@
 #define _ANALOG_DEVICE_ABSTRACTION_H_
 
 #include "PlatformDetermination.h"
-#include <BasicIoAbstraction.h>
+#include "BasicIoAbstraction.h"
 
 /**
  * @file AnalogDeviceAbstraction.h

--- a/src/DeviceEvents.h
+++ b/src/DeviceEvents.h
@@ -11,9 +11,9 @@
  * @brief This file contains events that are associated with the device, such as the Analog Device.
  */
 
-#include "TaskManagerIO.h"
-#include "PlatformDetermination.h"
-#include "AnalogDeviceAbstraction.h"
+#include <TaskManagerIO.h>
+#include <PlatformDetermination.h>
+#include <AnalogDeviceAbstraction.h>
 
 /**
  * An event that triggers when a certain analog condition is reached, based on a made and a threshold. It can either

--- a/src/EepromAbstraction.cpp
+++ b/src/EepromAbstraction.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 https://www.thecoderscorner.com (Dave Cherry).
  * This product is licensed under an Apache license, see the LICENSE file in the top-level directory.
  */
-#include <EepromAbstraction.h>
+#include "EepromAbstraction.h"
 
 #ifdef __AVR__
 

--- a/src/EepromAbstractionWire.cpp
+++ b/src/EepromAbstractionWire.cpp
@@ -4,8 +4,8 @@
  */
 
 #include "PlatformDetermination.h"
-#include "IoLogging.h"
-#include <EepromAbstractionWire.h>
+#include <IoLogging.h>
+#include "EepromAbstractionWire.h"
 
 #ifdef WIRE_BUFFER_SIZE
 # define MAX_BUFFER_SIZE_TO_USE WIRE_BUFFER_SIZE

--- a/src/EepromAbstractionWire.h
+++ b/src/EepromAbstractionWire.h
@@ -13,7 +13,7 @@
 
 #include "PlatformDeterminationWire.h"
 #include "EepromAbstraction.h"
-#include <TaskManager.h>
+#include "TaskManager.h"
 
 /**
  * Defines all the variants of the chip that we can pass to the I2cAt24Eeprom constructor. From this we can determine

--- a/src/KeyboardManager.cpp
+++ b/src/KeyboardManager.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "KeyboardManager.h"
-#include "IoLogging.h"
+#include <IoLogging.h>
 
 MatrixKeyboardManager* MatrixKeyboardManager::INSTANCE = nullptr;
 

--- a/src/MockEepromAbstraction.h
+++ b/src/MockEepromAbstraction.h
@@ -2,7 +2,7 @@
 #define _MOCK_EEPROM_ABSTRACTION_H_
 
 #include "EepromAbstraction.h"
-#include "IoLogging.h"
+#include <IoLogging.h>
 
 /**
  * @ file MockEepromAbstraction.h

--- a/src/MockIoAbstraction.h
+++ b/src/MockIoAbstraction.h
@@ -12,7 +12,7 @@
  * Neither of the implementations in this file are designed for use in production.
  */
 
-#include <IoAbstraction.h>
+#include "IoAbstraction.h"
 
 /**
  * During any call to the mock version of IoAbstraction, any error detected

--- a/src/ResistiveTouchScreen.cpp
+++ b/src/ResistiveTouchScreen.cpp
@@ -1,5 +1,5 @@
 #include "ResistiveTouchScreen.h"
-#include "SwitchInput.h>"
+#include "SwitchInput.h"
 
 namespace iotouch {
 

--- a/src/ResistiveTouchScreen.cpp
+++ b/src/ResistiveTouchScreen.cpp
@@ -1,5 +1,5 @@
 #include "ResistiveTouchScreen.h"
-#include <SwitchInput.h>
+#include "SwitchInput.h>"
 
 namespace iotouch {
 

--- a/src/SwitchInput.cpp
+++ b/src/SwitchInput.cpp
@@ -5,6 +5,7 @@
 
 #include <inttypes.h>
 #include "SwitchInput.h"
+#include "BasicIoAbstraction.h"
 
 #define ONE_TURN_OF_ENCODER 32
 
@@ -427,8 +428,8 @@ int AbstractHwRotaryEncoder::amountFromChange(unsigned long change) {
 
 void HardwareRotaryEncoder::encoderChanged() {
     // Read the current states of pins A and B
-    uint8_t a = digitalRead(pinA);
-    uint8_t b = digitalRead(pinB);
+    uint8_t a = switches.getIoAbstraction()->digitalRead(pinA);
+    uint8_t b = switches.getIoAbstraction()->digitalRead(pinB);
 
     /**
      * Calculate the new state from signals A and B.

--- a/src/SwitchInput.h
+++ b/src/SwitchInput.h
@@ -14,8 +14,8 @@
 #ifndef _SWITCHINPUT_H
 #define _SWITCHINPUT_H
 
-#include <IoAbstraction.h>
-#include <TaskManager.h>
+#include "IoAbstraction.h"
+#include "TaskManager.h"
 #include <SimpleCollections.h>
 
 // START user adjustable section

--- a/src/pico/PicoDigitalIO.cpp
+++ b/src/pico/PicoDigitalIO.cpp
@@ -1,7 +1,7 @@
 
 #include "PicoDigitalIO.h"
-#include "../IoAbstraction.h"
-#include <SimpleCollections.h>
+#include "IoAbstraction.h"
+#include "SimpleCollections.h"
 
 #ifdef BUILD_FOR_PICO_CMAKE
 

--- a/src/wireHelpers.h
+++ b/src/wireHelpers.h
@@ -9,7 +9,7 @@
 #include "IoAbstraction.h"
 #include "PlatformDetermination.h"
 #include "PlatformDeterminationWire.h"
-#include "IoLogging.h"
+#include <IoLogging.h>
 
 /**
  * @file wireHelpers.h


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.